### PR TITLE
Bump to version 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/recaptcha-manager",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/recaptcha-manager",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/lazy-loader-service": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Makes a major bump to 1.0.0 per [these instructions](https://github.com/internetarchive/iaux-typescript-wc-template?tab=readme-ov-file#releasing-production-level-package), includes dependency and config updates.