### PR TITLE
WEBDEV-7722 Add timeout to reject the ReCaptcha load promise if the callback hasn't been run

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -1,5 +1,5 @@
 import { html, css, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, state, query } from 'lit/decorators.js';
 import { RecaptchaWidgetInterface } from '../src/recaptcha-widget';
 import {
   RecaptchaManager,
@@ -12,6 +12,8 @@ export class AppRoot extends LitElement {
 
   @state() result2?: string;
 
+  @query('#timeout') timeoutInput!: HTMLInputElement;
+
   private recaptchaManager: RecaptchaManagerInterface = new RecaptchaManager({
     defaultSiteKey: '6Ld64a8UAAAAAGbDwi1927ztGNw7YABQ-dqzvTN2',
   });
@@ -22,6 +24,18 @@ export class AppRoot extends LitElement {
 
   render() {
     return html`
+      <label for="timeout">
+        Timeout (ms):
+        <input
+          type="number"
+          id="timeout"
+          value="10000"
+          min="0"
+          max="99999"
+          step="100"
+          @change=${this.updateTimeout}
+        />
+      </label>
       <p>
         <button @click="${this.loadRecaptcha}">Load Recaptcha</button
         ><button @click="${this.executeRecaptcha}">Execute Recaptcha</button>
@@ -41,6 +55,10 @@ export class AppRoot extends LitElement {
             <p>${this.result2}</p>`
         : ''}
     `;
+  }
+
+  private updateTimeout() {
+    this.recaptchaManager.setTimeoutDelay(+this.timeoutInput.value);
   }
 
   private async loadRecaptcha() {

--- a/src/recaptcha-manager.ts
+++ b/src/recaptcha-manager.ts
@@ -31,7 +31,7 @@ export class RecaptchaManager implements RecaptchaManagerInterface {
   /**
    * How long in milliseconds to wait for the recaptcha library to load before timing out.
    */
-  private timeout: number;
+  private timeout = RecaptchaManager.DEFAULT_TIMEOUT;
 
   constructor(options?: {
     defaultSiteKey?: string;

--- a/src/recaptcha-manager.ts
+++ b/src/recaptcha-manager.ts
@@ -6,6 +6,11 @@ import { RecaptchaWidget, RecaptchaWidgetInterface } from './recaptcha-widget';
 
 export interface RecaptchaManagerInterface {
   /**
+   * Changes the manager's timeout delay to the given number of milliseconds.
+   */
+  setTimeoutDelay(delay: number): void;
+
+  /**
    * Load a recaptcha widget for a given site key or the default site key.
    */
   getRecaptchaWidget(options?: {
@@ -38,6 +43,11 @@ export class RecaptchaManager implements RecaptchaManagerInterface {
     this.lazyLoader = options?.lazyLoader ?? new LazyLoaderService();
     this.grecaptchaLibraryCache = options?.grecaptchaLibrary;
     this.timeout = options?.timeout ?? RecaptchaManager.DEFAULT_TIMEOUT;
+  }
+
+  /** @inheritdoc */
+  setTimeoutDelay(delay: number): void {
+    this.timeout = delay;
   }
 
   /** @inheritdoc */

--- a/src/recaptcha-manager.ts
+++ b/src/recaptcha-manager.ts
@@ -15,20 +15,29 @@ export interface RecaptchaManagerInterface {
 }
 
 export class RecaptchaManager implements RecaptchaManagerInterface {
+  private static readonly DEFAULT_TIMEOUT = 10000;
+
   private lazyLoader: LazyLoaderServiceInterface;
 
   private defaultSiteKey?: string;
 
   private recaptchaCache: Record<string, RecaptchaWidget> = {};
 
+  /**
+   * How long in milliseconds to wait for the recaptcha library to load before timing out.
+   */
+  private timeout: number;
+
   constructor(options?: {
     defaultSiteKey?: string;
     lazyLoader?: LazyLoaderServiceInterface;
     grecaptchaLibrary?: ReCaptchaV2.ReCaptcha; // allows dependency injection or will be lazy loaded
+    timeout?: number;
   }) {
     this.defaultSiteKey = options?.defaultSiteKey;
     this.lazyLoader = options?.lazyLoader ?? new LazyLoaderService();
     this.grecaptchaLibraryCache = options?.grecaptchaLibrary;
+    this.timeout = options?.timeout ?? RecaptchaManager.DEFAULT_TIMEOUT;
   }
 
   /** @inheritdoc */
@@ -58,7 +67,7 @@ export class RecaptchaManager implements RecaptchaManagerInterface {
   }
 
   /**
-   * Load the Recaptch library from Google.
+   * Load the Recaptcha library from Google.
    *
    * @returns Promise<ReCaptchaV2.ReCaptcha>
    */
@@ -66,7 +75,7 @@ export class RecaptchaManager implements RecaptchaManagerInterface {
     if (this.grecaptchaLibraryCache) {
       return this.grecaptchaLibraryCache;
     }
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).grecaptchaLoadedCallback = (): void => {
         setTimeout(() => {
@@ -77,6 +86,11 @@ export class RecaptchaManager implements RecaptchaManagerInterface {
         this.grecaptchaLibraryCache = window.grecaptcha;
         resolve(window.grecaptcha);
       };
+
+      setTimeout(
+        () => reject(new Error('grecaptcha failed to execute callback')),
+        this.timeout,
+      );
 
       this.lazyLoader.loadScript({
         src: 'https://www.google.com/recaptcha/api.js?onload=grecaptchaLoadedCallback&render=explicit',

--- a/test/mock-lazy-loader.ts
+++ b/test/mock-lazy-loader.ts
@@ -5,10 +5,11 @@ import {
   LazyLoaderServiceInterface,
 } from '@internetarchive/lazy-loader-service';
 import { Unsubscribe } from 'nanoevents';
-import { MockGrecaptcha } from './mock-grecaptcha';
 
 export class MockLazyLoaderService implements LazyLoaderServiceInterface {
   loadScriptSrc?: string;
+
+  constructor(private onloadFn: () => unknown = () => {}) {}
 
   on<E extends keyof LazyLoaderServiceEvents>(
     event: E,
@@ -30,10 +31,6 @@ export class MockLazyLoaderService implements LazyLoaderServiceInterface {
     attributes?: Record<string, string>;
   }): Promise<void> {
     this.loadScriptSrc = options.src;
-    window.grecaptcha = new MockGrecaptcha({
-      mode: 'success',
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).grecaptchaLoadedCallback();
+    this.onloadFn();
   }
 }

--- a/test/recaptcha-manager.test.ts
+++ b/test/recaptcha-manager.test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@open-wc/testing';
 import { MockGrecaptcha } from './mock-grecaptcha';
 import { RecaptchaManager } from '../src/recaptcha-manager';
-import { TimeoutError } from '../src/util/timed-promise';
 import { MockLazyLoaderService } from './mock-lazy-loader';
 
 const mockLazyLoader = new MockLazyLoaderService();
@@ -70,6 +69,7 @@ describe('ReCaptcha Management', () => {
       const recaptchaManager = new RecaptchaManager({
         lazyLoader: mockLazyLoaderWithCallback,
         defaultSiteKey: '123',
+        timeout: 100,
       });
 
       await recaptchaManager.getRecaptchaWidget();
@@ -83,14 +83,17 @@ describe('ReCaptcha Management', () => {
       const recaptchaManager = new RecaptchaManager({
         lazyLoader: mockLazyLoader,
         defaultSiteKey: '123',
+        timeout: 100,
       });
 
       try {
         await recaptchaManager.getRecaptchaWidget();
         expect.fail('recaptcha load did not time out as expected');
       } catch (err) {
-        expect(err).to.be.instanceOf(TimeoutError);
-        expect((err as TimeoutError).message).to.equal('Operation timed out');
+        expect(err).to.be.instanceOf(Error);
+        expect((err as Error).message).to.equal(
+          'grecaptcha failed to execute callback',
+        );
       }
     });
   });

--- a/test/recaptcha-manager.test.ts
+++ b/test/recaptcha-manager.test.ts
@@ -96,6 +96,25 @@ describe('ReCaptcha Management', () => {
         );
       }
     });
+
+    it('can set the timeout delay', async () => {
+      const recaptchaManager = new RecaptchaManager({
+        lazyLoader: mockLazyLoader,
+        defaultSiteKey: '123',
+      });
+
+      recaptchaManager.setTimeoutDelay(1);
+
+      try {
+        await recaptchaManager.getRecaptchaWidget();
+        expect.fail('recaptcha load did not time out as expected');
+      } catch (err) {
+        expect(err).to.be.instanceOf(Error);
+        expect((err as Error).message).to.equal(
+          'grecaptcha failed to execute callback',
+        );
+      }
+    });
   });
 
   describe('ReCaptcha Widget', () => {

--- a/test/recaptcha-manager.test.ts
+++ b/test/recaptcha-manager.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 import { MockGrecaptcha } from './mock-grecaptcha';
 import { RecaptchaManager } from '../src/recaptcha-manager';
+import { TimeoutError } from '../src/util/timed-promise';
 import { MockLazyLoaderService } from './mock-lazy-loader';
 
 const mockLazyLoader = new MockLazyLoaderService();
@@ -57,15 +58,40 @@ describe('ReCaptcha Management', () => {
     });
 
     it('loads the recaptcha library if needed', async () => {
+      // Mock lazy loader that mimics the grecaptcha script calling the callback on load
+      const mockLazyLoaderWithCallback = new MockLazyLoaderService(() => {
+        window.grecaptcha = new MockGrecaptcha({
+          mode: 'success',
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).grecaptchaLoadedCallback();
+      });
+
+      const recaptchaManager = new RecaptchaManager({
+        lazyLoader: mockLazyLoaderWithCallback,
+        defaultSiteKey: '123',
+      });
+
+      await recaptchaManager.getRecaptchaWidget();
+      const loadUrl = mockLazyLoaderWithCallback.loadScriptSrc;
+      expect(
+        loadUrl?.includes('recaptcha/api.js?onload=grecaptchaLoadedCallback'),
+      ).to.be.true;
+    });
+
+    it('rejects after specified timeout if grecaptcha fails to execute callback', async () => {
       const recaptchaManager = new RecaptchaManager({
         lazyLoader: mockLazyLoader,
         defaultSiteKey: '123',
       });
-      await recaptchaManager.getRecaptchaWidget();
-      const loadUrl = mockLazyLoader.loadScriptSrc;
-      expect(
-        loadUrl?.includes('recaptcha/api.js?onload=grecaptchaLoadedCallback'),
-      ).to.be.true;
+
+      try {
+        await recaptchaManager.getRecaptchaWidget();
+        expect.fail('recaptcha load did not time out as expected');
+      } catch (err) {
+        expect(err).to.be.instanceOf(TimeoutError);
+        expect((err as TimeoutError).message).to.equal('Operation timed out');
+      }
     });
   });
 


### PR DESCRIPTION
Currently if loading the ReCaptcha library fails, it never executes the manager's callback. As a result, the manager's own `getRecaptchaWidget` promise never resolves, leaving consumers waiting indefinitely unless they define their own timeouts.

This PR adds a configurable `timeout` option to the manager, and causes the widget promise to be rejected if ReCaptcha doesn't call the callback within the time limit.