### PR TITLE
v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/recaptcha-manager",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/recaptcha-manager",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/lazy-loader-service": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version includes the `timeout` option for the widget request to reject after a delay if the grecaptcha load fails.